### PR TITLE
[FIX] Error while generating command using CLI on MacOS

### DIFF
--- a/example/yor.json
+++ b/example/yor.json
@@ -1,0 +1,4 @@
+{
+  "project": "yor",
+  "info": "Save Discord token inside an environment variable."
+}

--- a/packages/cli/src/handlers/base.ts
+++ b/packages/cli/src/handlers/base.ts
@@ -54,7 +54,7 @@ export abstract class BaseHandler {
       file = `${componentName}.ts`;
     }
 
-    const dest = path.join(process.cwd(), 'src', `${component}s`, file);
+    const dest = path.relative(process.cwd(), path.join(process.cwd(), 'src', `${component}s`, file));
     if (existsSync(dest)) {
       console.error(`${chalk.redBright('× Error:')} Component already exist.`);
       process.exit(1);


### PR DESCRIPTION
Basically absolute path was causing conflicts while doing `fs` operations.